### PR TITLE
Feature: Manifest Export for CI Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Use `fmp` in your CI/CD pipelines to review PRs automatically.
 | `resolve-git` | Clone external GitRepository sources | `false` |
 | `sort` | Sort output for deterministic diffs | `false` |
 | `exclude-crds` | Strip CRDs from output | `false` |
+| `export-dir` | Export rendered manifests to this directory | |
+| `export-changed-only` | Only export manifests that have changed | `false` |
 | `config` | Explicit path to `.fmp.yaml` | *auto-discovered* |
 | `filter` | KIO filter YAML (overrides `.fmp.yaml`) | |
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: Strip CustomResourceDefinitions from output
     required: false
     default: 'false'
+  export-dir:
+    description: 'Export rendered manifests to this directory'
+    required: false
+    default: ''
+  export-changed-only:
+    description: 'Only export manifests that have changed'
+    required: false
+    default: 'false'
   # Legacy inputs for backward compatibility with the two-checkout workflow
   repo-a:
     description: '(Legacy) Path to the base repository checkout'
@@ -99,6 +107,12 @@ runs:
           if [[ -n "${{ inputs.helm }}" ]]; then
             export FMP_RENDER_HELM="${{ inputs.helm }}"
           fi
+          if [[ -n "${{ inputs.export-dir }}" ]]; then
+            export FMP_EXPORT_DIR="${{ inputs.export-dir }}"
+          fi
+          if [[ "${{ inputs.export-changed-only }}" == "true" ]]; then
+            export FMP_EXPORT_CHANGED_ONLY="true"
+          fi
           DIFF=$(fmp ci)
           echo "$DIFF"
           {
@@ -141,6 +155,12 @@ runs:
         fi
         if [[ "${{ inputs.exclude-crds }}" == "true" ]]; then
           FMP_ARGS+=("--exclude-crds")
+        fi
+        if [[ -n "${{ inputs.export-dir }}" ]]; then
+          FMP_ARGS+=("--export-dir" "${{ inputs.export-dir }}")
+        fi
+        if [[ "${{ inputs.export-changed-only }}" == "true" ]]; then
+          FMP_ARGS+=("--export-changed-only")
         fi
 
         echo "::group::fmp diff ${FMP_ARGS[*]}"

--- a/cmd/fmp/diff_source.go
+++ b/cmd/fmp/diff_source.go
@@ -45,7 +45,7 @@ func validateDiffArgs(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runDiff(log logr.Logger, args []string, out io.Writer) error {
+func runDiff(log logr.Logger, args []string, out io.Writer, exportDir string, exportChangedOnly bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("determining current directory: %w", err)
@@ -84,7 +84,7 @@ func runDiff(log logr.Logger, args []string, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("error creating preview: %w", err)
 	}
-	return p.Diff(leftPath, rightPath, out)
+	return p.Diff(leftPath, rightPath, out, exportDir, exportChangedOnly)
 }
 
 func resolveDiffPlan(args []string, cwd string) (*diffPlan, error) {

--- a/cmd/fmp/main.go
+++ b/cmd/fmp/main.go
@@ -33,6 +33,8 @@ var (
 	configFile     string
 	outputFormat   string
 	helmRelease    string
+	exportDir      string
+	exportChanged  bool
 	initConfig     bool
 
 	helmRegistryConfig   string
@@ -67,6 +69,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&helmRegistryConfig, "registry-config", "", "Helm Registry Config")
 	rootCmd.PersistentFlags().StringVar(&helmRepositoryConfig, "repository-config", "", "Helm Repository Config")
 	rootCmd.PersistentFlags().StringVar(&helmRepositoryCache, "repository-cache", "", "Helm Repository Cache")
+	rootCmd.PersistentFlags().StringVar(&exportDir, "export-dir", "", "Export rendered manifests to this directory")
+	rootCmd.PersistentFlags().BoolVar(&exportChanged, "export-changed-only", false, "Only export manifests that have changed")
 
 	renderCmd := &cobra.Command{
 		Use:   "render <path>",
@@ -108,7 +112,7 @@ inputs, use explicit git: or path: prefixes.`,
 		Args: validateDiffArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := cliLogger()
-			return runDiff(log, args, os.Stdout)
+			return runDiff(log, args, os.Stdout, exportDir, exportChanged)
 		},
 	}
 	diffCmd.Flags().StringVar(&helmRelease, "hr", "", "Filter diff to a specific HelmRelease by name")
@@ -201,6 +205,12 @@ CLI flags and FMP_* env vars override the config file.`,
 			if v := os.Getenv("FMP_RENDER_HELM"); v != "" {
 				renderHelm = v == "true" || v == "1"
 			}
+			if v := os.Getenv("FMP_EXPORT_DIR"); v != "" {
+				exportDir = v
+			}
+			if v := os.Getenv("FMP_EXPORT_CHANGED_ONLY"); v != "" {
+				exportChanged = v == "true" || v == "1"
+			}
 
 			configRepo := repoA
 			if explicitConfig := os.Getenv("FMP_CONFIG"); explicitConfig != "" {
@@ -221,7 +231,7 @@ CLI flags and FMP_* env vars override the config file.`,
 			if err != nil {
 				return fmt.Errorf("error creating preview: %w", err)
 			}
-			return p.Diff(repoA, repoB, os.Stdout)
+			return p.Diff(repoA, repoB, os.Stdout, exportDir, exportChanged)
 		},
 	}
 	versionCmd := &cobra.Command{

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -3,6 +3,8 @@ package diff
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
@@ -12,8 +14,10 @@ import (
 )
 
 // Diff computes a unified diff between two Renders and writes the result to w.
-
-func Diff(a, b *render.Render, w io.Writer) error {
+// If exportDir is provided, the rendered manifests from the target (b) will be
+// written as individual YAML files to the directory. If exportChangedOnly is true,
+// only the added or modified resources will be exported.
+func Diff(a, b *render.Render, w io.Writer, exportDir string, exportChangedOnly bool) error {
 	var added, deleted, modified []resid.ResId
 	for _, ra := range a.Resources() {
 		if _, err := b.GetByCurrentId(ra.CurId()); err != nil {
@@ -28,9 +32,12 @@ func Diff(a, b *render.Render, w io.Writer) error {
 		}
 	}
 
+	changedIds := make(map[string]bool)
+
 	for _, c := range added {
 		r, _ := b.GetByCurrentId(c)
 		yaml := r.MustYaml()
+		changedIds[c.String()] = true
 		edits := myers.ComputeEdits(span.URIFromPath(c.String()), "", yaml)
 		if _, err := fmt.Fprint(w, gotextdiff.ToUnified(c.String(), c.String(), "", edits)); err != nil {
 			return err
@@ -56,10 +63,36 @@ func Diff(a, b *render.Render, w io.Writer) error {
 			continue
 		}
 
+		changedIds[m.String()] = true
 		edits := myers.ComputeEdits(span.URIFromPath(m.String()), aYaml, bYaml)
 		if _, err := fmt.Fprint(w, gotextdiff.ToUnified(m.String(), m.String(), aYaml, edits)); err != nil {
 			return err
 		}
 	}
+
+	if exportDir != "" {
+		if err := os.MkdirAll(exportDir, 0755); err != nil {
+			return fmt.Errorf("creating export dir: %w", err)
+		}
+		for _, rb := range b.Resources() {
+			if exportChangedOnly && !changedIds[rb.CurId().String()] {
+				continue
+			}
+
+			// Format filename: namespace_kind_name.yaml
+			ns := rb.GetNamespace()
+			if ns == "" {
+				ns = "cluster"
+			}
+			filename := fmt.Sprintf("%s_%s_%s.yaml", ns, rb.GetKind(), rb.GetName())
+			filename = filepath.Join(exportDir, filename)
+
+			content := fmt.Sprintf("---\n%s", string(rb.MustYaml()))
+			if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+				return fmt.Errorf("writing exported manifest %s: %w", filename, err)
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -239,7 +239,9 @@ func (p *Preview) Test(path string, out io.Writer) error {
 
 // Diff computes and writes the diff between two repository paths.
 // If a HelmRelease filter is set, only resources from that release are included.
-func (p *Preview) Diff(a, b string, out io.Writer) error {
+// If exportDir is provided, the rendered manifests from the target (b) will be
+// written as individual YAML files to the directory.
+func (p *Preview) Diff(a, b string, out io.Writer, exportDir string, exportChangedOnly bool) error {
 	g, _ := errgroup.WithContext(p.ctx)
 	var ar, br *loadRepoResult
 	g.Go(func() error {
@@ -263,7 +265,7 @@ func (p *Preview) Diff(a, b string, out io.Writer) error {
 
 	p.applyOutputOptions(ar.render)
 	p.applyOutputOptions(br.render)
-	if err := diff.Diff(ar.render, br.render, out); err != nil {
+	if err := diff.Diff(ar.render, br.render, out, exportDir, exportChangedOnly); err != nil {
 		return fmt.Errorf("diff error: %w", err)
 	}
 	var allErrors []error


### PR DESCRIPTION
This PR extends the  CLI and GitHub Action with manifest export capabilities. This allows users to easily pass rendered manifests (or just the changed ones) to external validation tools like  or OPA.

### Key Changes:
- **CLI Flags**: Added  and  to  and .
- **Zero Overhead**: The export logic is integrated into the existing diff pass, reusing in-memory rendered resources.
- **Flat Output**: Files are written as  in a flat directory for easy globbing.
- **GitHub Action Inputs**: Added  and  inputs to .

### Usage Example:
```yaml
- uses: tobiash/flux-manifest-preview@main
  with:
    export-dir: ./rendered-manifests
    export-changed-only: true

- name: Run Kubeconform
  run: kubeconform ./rendered-manifests/*.yaml
```