### PR TITLE
fix: normalize Helm rendered namespaces

### DIFF
--- a/pkg/expander/helm/runner.go
+++ b/pkg/expander/helm/runner.go
@@ -207,7 +207,73 @@ func (r *Runner) renderChart(ctx context.Context, t *RenderTask) (resmap.ResMap,
 		return nil, fmt.Errorf("running post renderer: %w", err)
 	}
 	manifests = *renderedManifests
-	return parseManifests(manifests.Bytes(), r.logger)
+	resources, err := parseManifests(manifests.Bytes(), r.logger)
+	if err != nil {
+		return nil, err
+	}
+	applyNamespaceToRenderedResources(resources, t.namespace)
+	return resources, nil
+}
+
+func applyNamespaceToRenderedResources(resources resmap.ResMap, namespace string) {
+	if namespace == "" {
+		return
+	}
+	clusterScopedGVKs := clusterScopedGVKsFromCRDs(resources)
+	for _, res := range resources.Resources() {
+		if !isClusterScopedRenderedResource(res, clusterScopedGVKs) && res.GetNamespace() == "" {
+			_ = res.SetNamespace(namespace)
+		}
+	}
+}
+
+func isClusterScopedRenderedResource(res *resource.Resource, clusterScopedGVKs map[string]bool) bool {
+	gvk := res.GetGvk()
+	return gvk.IsClusterScoped() ||
+		isKnownClusterScopedRenderedGVK(gvk.Group, gvk.Kind) ||
+		clusterScopedGVKs[gvkScopeKey(gvk.Group, gvk.Kind)]
+}
+
+func isKnownClusterScopedRenderedGVK(group, kind string) bool {
+	switch gvkScopeKey(group, kind) {
+	case gvkScopeKey("snapshot.storage.k8s.io", "VolumeSnapshotClass"):
+		return true
+	default:
+		return false
+	}
+}
+
+func clusterScopedGVKsFromCRDs(resources resmap.ResMap) map[string]bool {
+	clusterScopedGVKs := make(map[string]bool)
+	for _, res := range resources.Resources() {
+		gvk := res.GetGvk()
+		if gvk.Group != "apiextensions.k8s.io" || gvk.Kind != "CustomResourceDefinition" {
+			continue
+		}
+
+		obj, err := res.Map()
+		if err != nil {
+			continue
+		}
+		spec, ok := obj["spec"].(map[string]any)
+		if !ok || spec["scope"] != "Cluster" {
+			continue
+		}
+		names, ok := spec["names"].(map[string]any)
+		if !ok {
+			continue
+		}
+		group, groupOK := spec["group"].(string)
+		kind, kindOK := names["kind"].(string)
+		if groupOK && kindOK {
+			clusterScopedGVKs[gvkScopeKey(group, kind)] = true
+		}
+	}
+	return clusterScopedGVKs
+}
+
+func gvkScopeKey(group, kind string) string {
+	return group + "/" + kind
 }
 
 func runPostRenderer(renderer PostRenderer, manifests *bytes.Buffer) (*bytes.Buffer, error) {

--- a/pkg/expander/helm/runner_test.go
+++ b/pkg/expander/helm/runner_test.go
@@ -22,6 +22,13 @@ metadata:
 data:
   value: ok
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: omitted-namespace
+data:
+  value: ok
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -49,6 +56,32 @@ driver: rook-ceph.rbd.csi.ceph.com
 deletionPolicy: Delete
 parameters:
   clusterID: {{ .Release.Namespace }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterwidgets.example.com
+spec:
+  group: example.com
+  scope: Cluster
+  names:
+    plural: clusterwidgets
+    singular: clusterwidget
+    kind: ClusterWidget
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+---
+apiVersion: example.com/v1
+kind: ClusterWidget
+metadata:
+  name: test-widget
+spec:
+  value: ok
 `)
 
 	runner := NewRunner(helmcli.New(), logr.Discard())
@@ -68,6 +101,13 @@ parameters:
 	}
 	if got := configMap.GetNamespace(); got != "demo-ns" {
 		t.Fatalf("ConfigMap namespace = %q, want demo-ns", got)
+	}
+	omittedNamespaceConfigMap, err := resources.GetById(resid.NewResIdWithNamespace(resid.NewGvk("", "v1", "ConfigMap"), "omitted-namespace", "demo-ns"))
+	if err != nil {
+		t.Fatalf("GetById(omitted namespace configmap) error = %v", err)
+	}
+	if got := omittedNamespaceConfigMap.GetNamespace(); got != "demo-ns" {
+		t.Fatalf("omitted namespace ConfigMap namespace = %q, want demo-ns", got)
 	}
 
 	webhook, err := resources.GetById(resid.NewResId(resid.NewGvk("admissionregistration.k8s.io", "v1", "ValidatingWebhookConfiguration"), "test-webhook"))
@@ -99,6 +139,18 @@ parameters:
 	}
 	if clusterID := snapMap["parameters"].(map[string]any)["clusterID"]; clusterID != "demo-ns" {
 		t.Fatalf("snapshot class clusterID = %v, want demo-ns", clusterID)
+	}
+
+	widget, err := resources.GetById(resid.NewResId(resid.NewGvk("example.com", "v1", "ClusterWidget"), "test-widget"))
+	if err != nil {
+		t.Fatalf("GetById(cluster widget) error = %v", err)
+	}
+	widgetMap, err := widget.Map()
+	if err != nil {
+		t.Fatalf("widget.Map() error = %v", err)
+	}
+	if _, found := widgetMap["metadata"].(map[string]any)["namespace"]; found {
+		t.Fatalf("expected ClusterWidget to remain cluster-scoped, got metadata.namespace=%v", widgetMap["metadata"].(map[string]any)["namespace"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Normalize Helm-rendered namespace-scoped resources without `metadata.namespace` to the effective release namespace.
- Preserve cluster-scoped resources, including CRD-declared cluster-scoped custom resources and VolumeSnapshotClass.
- Add regression coverage for omitted namespace resources and cluster-scoped resources.

## Testing
- `go test ./pkg/expander/helm -count=1`
- `go test ./...`
- `go vet ./...`

Closes #4